### PR TITLE
Always including jQuery conflicts

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration
                 ->scalarNode('theme_advanced_buttons3')->defaultValue("")->end()
                 // http://tinymce.moxiecode.com/wiki.php/Configuration:plugins
                 ->scalarNode('plugins')->defaultValue("")->end()
+                ->booleanNode('include_jquery')->defaultValue("true")->end()
                 
             ->end();
 

--- a/DependencyInjection/StfalconTinymceExtension.php
+++ b/DependencyInjection/StfalconTinymceExtension.php
@@ -27,6 +27,7 @@ class StfalconTinymceExtension extends Extension
         }
 
         $container->setParameter('stfalcon_tinymce.config', $config);
+        $container->setParameter('stfalcon_tinymce.include_jquery', isset($config['include_jquery']) ? $config['include_jquery'] : true);
 
         // load dependency injection config
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/Resources/views/Script/init.html.twig
+++ b/Resources/views/Script/init.html.twig
@@ -1,4 +1,6 @@
-<script type="text/javascript" src="{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/jquery-1.6.1.min.js') }}"></script>
+{% if include_jquery %}
+    <script type="text/javascript" src="{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/jquery-1.6.1.min.js') }}"></script>
+{% endif %}
 <script type="text/javascript" src="{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/jquery.tinymce.js') }}"></script>
 
 <script type="text/javascript">

--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -53,7 +53,8 @@ class StfalconTinymceExtension extends \Twig_Extension
     {
         //$assets = $this->getContainer()->get('templating.helper.assets');
         return ($this->getContainer()->get('templating')->render('StfalconTinymceBundle:Script:init.html.twig', array(
-            'tinymce_config_json' => json_encode($this->getContainer()->getParameter('stfalcon_tinymce.config'))
+            'tinymce_config_json' => json_encode($this->getContainer()->getParameter('stfalcon_tinymce.config')),
+            'include_jquery' => $this->getContainer()->getParameter('stfalcon_tinymce.include_jquery'),
         )));
     }
 


### PR DESCRIPTION
including jQuery conficts with other bundles or with projects that already have jQuery.

I added an option 'include_jquery' which you can set to false (default is true) so that you can avoid the bundle loading jquery and load your own.
