### PR TITLE
Fixed bundle to work in a project installed outside the root folder (changed assets paths from absolute to relative)

### DIFF
--- a/Resources/views/Script/init.html.twig
+++ b/Resources/views/Script/init.html.twig
@@ -1,7 +1,7 @@
 {% if include_jquery %}
-    <script type="text/javascript" src="{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/jquery-1.6.1.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset('bundles/stfalcontinymce/vendor/tiny_mce/jquery-1.6.1.min.js') }}"></script>
 {% endif %}
-<script type="text/javascript" src="{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/jquery.tinymce.js') }}"></script>
+<script type="text/javascript" src="{{ asset('bundles/stfalcontinymce/vendor/tiny_mce/jquery.tinymce.js') }}"></script>
 
 <script type="text/javascript">
     //<![CDATA[
@@ -9,7 +9,7 @@
     $('textarea.tinymce').each(function (){
             var attr = jQuery.parseJSON($(this).attr('tinymce'));
             var options =  (attr && attr.theme == 'simple') ? tinymce_options.theme.simple : tinymce_options.theme.advanced;
-            options.script_url = '{{ asset('/bundles/stfalcontinymce/vendor/tiny_mce/tiny_mce.js') }}';
+            options.script_url = '{{ asset('bundles/stfalcontinymce/vendor/tiny_mce/tiny_mce.js') }}';
             $(this).tinymce(options);
     });
     //]]>


### PR DESCRIPTION
If you use this bundle into an app installed in a server with absolute URL like this "www.aplication.com", it works fine. But if the application is installed in a subdirectory (ex: www.domain.com/application) this bundle doesn't work because the asset paths are absolutes. I have changed it and now it works over all URLs.
