### PR TITLE
handling of textareas with html5 required-attribute

### DIFF
--- a/Resources/views/Script/init.html.twig
+++ b/Resources/views/Script/init.html.twig
@@ -4,14 +4,27 @@
 <script type="text/javascript" src="{{ asset('bundles/stfalcontinymce/vendor/tiny_mce/jquery.tinymce.js') }}"></script>
 
 <script type="text/javascript">
-    //<![CDATA[
-    var tinymce_options = {{ tinymce_config_json|raw }};
-	var textarea = 'textarea{{textarea_class}}';
+//<![CDATA[
+(function($, undefined) {
+    var tinymce_options = {{ tinymce_config_json|raw }},
+        textarea = 'textarea{{textarea_class}}';
+
     $(textarea).each(function (){
-            var attr = jQuery.parseJSON($(this).attr('tinymce'));
-            var options =  (attr && attr.theme == 'simple') ? tinymce_options.theme.simple : tinymce_options.theme.advanced;
+            var $textarea = $(this),
+                attr = $.parseJSON($textarea.attr('tinymce')),
+                options = (attr && attr.theme == 'simple') ? tinymce_options.theme.simple : tinymce_options.theme.advanced;
+
             options.script_url = '{{ asset('bundles/stfalcontinymce/vendor/tiny_mce/tiny_mce.js') }}';
-            $(this).tinymce(options);
+
+            // workaround for an incompatibility with html5-validation (see: http://git.io/CMKJTw)
+            if($textarea.is('[required]')) {
+                options.oninit = function(editor) {
+                    editor.onChange.add(function(ed, l) { ed.save(); });
+                };
+            }
+
+            $textarea.tinymce(options);
     });
-    //]]>
+} (jQuery));
+//]]>
 </script>


### PR DESCRIPTION
tinyMCE doesn't work with textareas with a required-attribute, since the
constraint-validation that is triggered by the required-attribute will
prevent the 'submit'-event on the form which normally triggers tinyMCE
to save the editor-contents into the hidden textarea.

To circumvent this problem, an onchange-handler is attached to textareas with
the required-attribute that will update the textarea contents from the
editor when the focus leaves the editor (which is at least once before
the constraint-validation starts.

(fixes #18)
