### PR TITLE
Added branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
             "Stfalcon\\Bundle\\TinymceBundle": ""
         }
     },
-    "target-dir" : "Stfalcon/Bundle/TinymceBundle"
+    "target-dir" : "Stfalcon/Bundle/TinymceBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Hi, I've added a branch alias for master to allow more specific tracking of the bundle in composer. Also, this seems pretty stable so it would be good if there was a tag available to point at in composer rather than following branches.
