### PR TITLE
Display id on single text area if it exists

### DIFF
--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -68,15 +68,15 @@ function initTinyMCE(options) {
                 }
             }
 
-            if(false === textareas[i].hasAttribute('id')){
+            if (false === textareas[i].hasAttribute('id')) {
                 if (textareas.length == 1) {
                     // Single textarea, so we can init it without ID attribute
                     tinyMCE.execCommand('mceAddControl', true, textareas[i]);
-                } else{
+                } else {
                     // Skip some textarea without ID which unable to initialize and increase error's counter
                     err++;
                     continue;
-		}
+                }
             } else {
                 // Initialize textarea by its ID attribute
                 tinyMCE.execCommand('mceAddControl', true, textareas[i].getAttribute('id'));


### PR DESCRIPTION
If a single text area has an id, there should be no harm in displaying it as an application might be looking for IDs to manipulate the text area.

Thanks for considering this PR.
