### PR TITLE
Tinymce4 i18n

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -1,4 +1,5 @@
-mespace Stfalcon\Bundle\TinymceBundle\Twig\Extension;
+<?php
+namespace Stfalcon\Bundle\TinymceBundle\Twig\Extension;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 


### PR DESCRIPTION
Language files have changed in tinymce 4.x. They aren't always based on a 2 characters language code (en.js, ja.js, etc.) anymore. This PR updates the twig extension to take that fact into account -- the existing code is broken for languages like hu_HU or ka_GE -- and to allow a reasonable matching between the available tinymce languages and the application locale. 
