### PR TITLE
FileBrowser call fix

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -140,7 +140,7 @@ class StfalconTinymceExtension extends \Twig_Extension
         }
 
         return $this->getService('templating')->render('StfalconTinymceBundle:Script:init.html.twig', array(
-            'tinymce_config' => json_encode($config),
+            'tinymce_config' => preg_replace('/"file_browser_callback":"([^"]+)"\s*/', 'file_browser_callback:$1', json_encode($config)),
             'include_jquery' => $config['include_jquery'],
             'tinymce_jquery' => $config['tinymce_jquery'],
             'base_url'       => $this->baseUrl


### PR DESCRIPTION
FileBrowseCallback parameter shouldn't be escaped by quotes, according to this post
http://www.tinymce.com/forum/viewtopic.php?pid=107012#p107012
This fix removes quotes from config array, after jsonification, and make it able to work TinyMCE with filemanagers such as Elfinder and others.
