### PR TITLE
add option callback on init

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
             // Use jQuery (true) or standalone (false) build of the TinyMCE
             ->booleanNode('tinymce_jquery')->defaultFalse()->end()
             // Set init to true to use callback on the event init
-            ->booleanNode('init')->defaultFalse()->end()
+            ->booleanNode('use_callback_tinymce_init')->defaultFalse()->end()
             // Selector
             ->scalarNode('textarea_class')->end() // @deprecated
             ->scalarNode('selector')->end()

--- a/README.md
+++ b/README.md
@@ -223,4 +223,30 @@ If you specify a relative path, it is resolved in relation to the URL of the (HT
                 ...
 ```
 
+### Init Event
+
+As $(document).ready() in jQuery you can listen to the init event as well in Tinymce.
+
+To do so you must edit your config and set `use_callback_tinymce_init` to true.
+
+`app/config/config.yml`:
+
+```yaml
+    stfalcon_tinymce:
+        ...
+        use_callback_tinymce_init: true
+        ...
+
+```
+
+And then create a javascript callback function named `callback_tinymce_init` as follow
+
+```javascript
+
+function callback_tinymce_init() {
+    // execute your best script ever
+}
+
+```
+
 > NOTE! Read Official TinyMCE documentation for more details: http://www.tinymce.com/wiki.php/Configuration:content_css

--- a/Resources/public/js/init.jquery.js
+++ b/Resources/public/js/init.jquery.js
@@ -49,8 +49,8 @@ function initTinyMCE(options) {
                             tinymce.PluginManager.load(id, url);
                         }
                     });
-
-                    if(options.init){
+                    //Init Event
+                    if(options.use_callback_tinymce_init){
                         ed.on('init',function(){
                             var callback = window['callback_tinymce_init'];
                             if (typeof callback == 'function') {

--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -82,6 +82,17 @@ function initTinyMCE(options) {
 
                         })(buttonId, clone(options.tinymce_buttons[buttonId]));
                     }
+                    //Init Event
+                    if(options.use_callback_tinymce_init){
+                        editor.on('init',function(){
+                            var callback = window['callback_tinymce_init'];
+                            if (typeof callback == 'function') {
+                                callback();
+                            } else {
+                                alert('You have to create callback function: callback_tinymce_init');
+                            }
+                        });
+                    }
                 }
             }
             // Initialize textarea by its ID attribute


### PR DESCRIPTION
This change allows the developer to add a callback function on init event.

To use it, just add in your `config.yml` file :

```
stfalcon_tinymce:
    init: true
```

Next, you just have to add a function named `callback_tinymce_init()` in your javascript like this :

```
function callback_tinymce_init(){
    // script called on tinymce initialization ...
}
```
