### PR TITLE
Invalid elements

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,6 +33,8 @@ class Configuration implements ConfigurationInterface
             // Selector
             ->scalarNode('textarea_class')->end() // @deprecated
             ->scalarNode('selector')->end()
+            // Invalid tags
+            ->scalarNode('invalid_elements')->end()
             // base url for content
             ->scalarNode('base_url')->end()
             // Default language for all instances of the editor

--- a/README.md
+++ b/README.md
@@ -249,4 +249,20 @@ function callback_tinymce_init() {
 
 ```
 
+### Invalid elements
+
+TinyMce can clean your text from undesir html tags before submitting content.
+
+To do so you must specify a list of invalid tag separated by comma in your config file.
+
+`app/config/config.yml` 
+
+```yaml
+    stfalcon_tinymce:
+        ...
+        invalid_elements: 'span,a,img,...'
+        ...
+
+```
+
 > NOTE! Read Official TinyMCE documentation for more details: http://www.tinymce.com/wiki.php/Configuration:content_css

--- a/Resources/public/js/init.jquery.js
+++ b/Resources/public/js/init.jquery.js
@@ -61,6 +61,10 @@ function initTinyMCE(options) {
                         });
                     }
                 };
+                //Invalid tags
+                if(options.invalid_elements){
+                    settings.invalid_elements = options.invalid_elements;
+                }
                 textarea.tinymce(settings);
             });
         });

--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -95,6 +95,10 @@ function initTinyMCE(options) {
                     }
                 }
             }
+            //Invalid tags
+            if(options.invalid_elements){
+                settings.invalid_elements = options.invalid_elements;
+            }
             // Initialize textarea by its ID attribute
             tinymce
                 .createEditor(textareas[i].getAttribute('id'), settings)


### PR DESCRIPTION
This PR enable the `invalid_elements` option in the TinyMce init.
