### PR TITLE
Added the possibility to specify options through tinymceInit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ This bundle comes with an extension for Twig. This makes it very easy to include
     {{ tinymce_init() }}
 ```
 
+The helper also allows to overwrite global configurations. This is especially helpful if you have conditional plugins or
+you want to change editor settings on used-based choices.
+
+```twig
+    {{
+        tinymce_init({
+             selector: '.tinymce',
+             external_plugins: {
+                 filemanager: {
+                     url: 'asset[bundles/acmedemo/js/tinymce-plugin/filemanager/editor_plugin.js]'
+                 }
+             }
+             theme:{
+                advanced:{
+                    theme: 'modern'
+                    file_browser_callback : 'someCallback'
+                }
+             }
+             ...
+        })
+    }}
+```
+
 ## Base configuration
 
 By default, tinymce is enabled for all textareas on the page. If you want to customize it, do the following:

--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -82,7 +82,7 @@ class StfalconTinymceExtension extends \Twig_Extension
     public function tinymceInit($options = array())
     {
         $config = $this->getParameter('stfalcon_tinymce.config');
-        $config = array_merge($config, $options);
+        $config = array_merge_recursive($config, $options);
 
         $this->baseUrl = (!isset($config['base_url']) ? null : $config['base_url']);
         /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */

--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -75,11 +75,14 @@ class StfalconTinymceExtension extends \Twig_Extension
     /**
      * TinyMce initializations
      *
+     * @param array $options which can be used to overwrite the global configuration on call
+     *
      * @return string
      */
-    public function tinymceInit()
+    public function tinymceInit($options = array())
     {
         $config = $this->getParameter('stfalcon_tinymce.config');
+        $config = array_merge($config, $options);
 
         $this->baseUrl = (!isset($config['base_url']) ? null : $config['base_url']);
         /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */


### PR DESCRIPTION
The problem which this Commit tries to solve is described in https://github.com/stfalcon/TinymceBundle/issues/136

Problem (TLDR): There is no way to override the global configuration for sites which may have complex dependencies and don't want to include them everywhere thus leaving the theming configuration a bit too static and unusable.

Fix: We just let them provide the needed specific configuration through an optional 'options' array which can be declared as the tinymceInit TwgHelper is called.

Sidenote: This may also fix many other Issues that may could come up. In theory you could now also configure url for themes through the path() or url() helper making theming/configurating the tinyMce more flexible in general.