### PR TITLE
Fix Twig deprecation warning

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -68,7 +68,7 @@ class StfalconTinymceExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'tinymce_init' => new \Twig_Function_Method($this, 'tinymceInit', array('is_safe' => array('html')))
+            'tinymce_init' => new \Twig_SimpleFunction('tinymce_init', array($this, 'tinymceInit'), array('is_safe' => array('html')))
         );
     }
 


### PR DESCRIPTION
Fix for deprecated Twig method call (since Twig 1.12)