### PR TITLE
Manage file_picker_callback option

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -166,10 +166,12 @@ class StfalconTinymceExtension extends \Twig_Extension
         $tinymceConfiguration = preg_replace(
             array(
                 '/"file_browser_callback":"([^"]+)"\s*/',
+                '/"file_picker_callback":"([^"]+)"\s*/',
                 '/"paste_preprocess":"([^"]+)"\s*/',
             ),
             array(
                 'file_browser_callback:$1',
+                'file_picker_callback:$1',
                 '"paste_preprocess":$1',
             ),
             json_encode($config)


### PR DESCRIPTION
Hi,

I've added the possibility to use the file_picker_callback as the TinyMCE documentation says it replaces the old file_browser_callback:

> This replaces the old file_browser_callback.

[https://www.tinymce.com/docs/configure/file-image-upload/#file_picker_callback](url)

Thanks forward and for all the job that's already been done !