### PR TITLE
Require Symfony 3.0 or upper in master version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php":             ">=5.4.0",
-        "symfony/symfony": ">=2.1"
+        "symfony/symfony": ">=3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
As indicated in Readme, the master or 2.x version is based in Symfony 3.0 or upper