### PR TITLE
fixed faulty class selector

### DIFF
--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -18,7 +18,7 @@ function initTinyMCE(options) {
                 if (_t) textareas.push(_t);
                 break;
             case ".":
-                textareas = getElementsByClassName('.' + options.selector.substring(1), 'textarea');
+                textareas = getElementsByClassName(options.selector, 'textarea');
                 break;
             default :
                 textareas = document.getElementsByTagName('textarea');

--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -18,7 +18,7 @@ function initTinyMCE(options) {
                 if (_t) textareas.push(_t);
                 break;
             case ".":
-                textareas = getElementsByClassName(options.selector.substring(1), 'textarea');
+                textareas = getElementsByClassName('.' + options.selector.substring(1), 'textarea');
                 break;
             default :
                 textareas = document.getElementsByTagName('textarea');


### PR DESCRIPTION
When specifing a custom class selector all textareas are still selected.

This PR fixes this issue by adding a ``.`` in front of the selector in ``getElementsByClassName``, omitting the ``.`` will return all textareas.

This does not break BC since this feature wasn't working to begin with,.