### PR TITLE
Use request from stack only when available

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -126,8 +126,14 @@ class StfalconTinymceExtension extends \Twig_Extension
 
         // If the language is not set in the config...
         if (!isset($config['language']) || empty($config['language'])) {
-            // get it from the request
-            $config['language'] = $this->container->get('request_stack')->getCurrentRequest()->getLocale();
+            // get it from the request, if available
+            $currentRequest = $this->container->get('request_stack')
+                ->getCurrentRequest()
+            ;
+
+            if ($currentRequest) {
+                $config['language'] = $currentRequest->getLocale();
+            }
         }
 
         $config['language'] = LocaleHelper::getLanguage($config['language']);


### PR DESCRIPTION
When using Twig from CLI there is of course no request in the stack and this causes a null reference issue.

This PR fixes the issue.
