### PR TITLE
symfony4 support

### DIFF
--- a/Resources/config/service.xml
+++ b/Resources/config/service.xml
@@ -12,6 +12,7 @@
         <!-- T W I G   H E L P E R S -->
         <service id="twig.extension.stfalcon_tinymce" class="%stfalcon_tinymce.twig.extension.class%">
             <argument type="service" id="service_container" />
+            <argument type="service" id="assets.packages" />
             <tag name="twig.extension" alias="stfalcon_tinymce" />
         </service>
     </services>

--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -2,6 +2,7 @@
 namespace Stfalcon\Bundle\TinymceBundle\Twig\Extension;
 
 use Stfalcon\Bundle\TinymceBundle\Helper\LocaleHelper;
+use Symfony\Component\Asset\Packages;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,13 +27,19 @@ class StfalconTinymceExtension extends \Twig_Extension
     protected $baseUrl;
 
     /**
+     * @var Packages
+     */
+    private $packages;
+
+    /**
      * Initialize tinymce helper
      *
      * @param ContainerInterface $container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, Packages $packages)
     {
         $this->container = $container;
+        $this->packages = $packages;
     }
 
     /**
@@ -94,7 +101,7 @@ class StfalconTinymceExtension extends \Twig_Extension
         unset($config['asset_package_name']);
 
         /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */
-        $assets = $this->getService('assets.packages');
+        $assets = $this->packages;
 
         // Get path to tinymce script for the jQuery version of the editor
         if ($config['tinymce_jquery']) {
@@ -180,7 +187,7 @@ class StfalconTinymceExtension extends \Twig_Extension
             json_encode($config)
         );
 
-        return $this->getService('templating')->render('StfalconTinymceBundle:Script:init.html.twig', array(
+        return $this->getService('twig')->render('@StfalconTinymce/Script/init.html.twig', array(
             'tinymce_config'     => $tinymceConfiguration,
             'include_jquery'     => $config['include_jquery'],
             'tinymce_jquery'     => $config['tinymce_jquery'],
@@ -208,8 +215,7 @@ class StfalconTinymceExtension extends \Twig_Extension
      */
     protected function getAssetsUrl($inputUrl)
     {
-        /** @var $assets \Symfony\Component\Templating\Helper\CoreAssetsHelper */
-        $assets = $this->getService('assets.packages');
+        $assets = $this->packages;
 
         $url = preg_replace('/^asset\[(.+)\]$/i', '$1', $inputUrl);
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     },
     "require": {
         "php":             ">=5.4.0",
-        "symfony/symfony": ">=3.0"
+        "symfony/framework-bundle": ">=3.0",
+        "symfony/twig-bundle": ">=3.0",
+        "symfony/asset":">=3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     },
     "require": {
         "php":             ">=5.4.0",
-        "symfony/framework-bundle": ">=3.0",
-        "symfony/twig-bundle": ">=3.0",
-        "symfony/asset":">=3.0"
+        "symfony/framework-bundle": "^3.0|^4.0",
+        "symfony/twig-bundle": "^3.0|^4.0",
+        "symfony/asset":"^3.0|^4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi,

as bundle uses `symfony/symfony` would not be compatible with upcoming Symfony 4.
This pull request tries to change this behaviour to directly require any needed dependencies

Tested on Symfony 3.3 and Symfony 4 Beta4

#SymfonyConHackday2017