### PR TITLE
Remove period (.) from class selector

### DIFF
--- a/Resources/public/js/init.standard.js
+++ b/Resources/public/js/init.standard.js
@@ -18,7 +18,7 @@ function initTinyMCE(options) {
                 if (_t) textareas.push(_t);
                 break;
             case ".":
-                textareas = getElementsByClassName(options.selector, 'textarea');
+                textareas = getElementsByClassName(options.selector.substring(1), 'textarea');
                 break;
             default :
                 textareas = document.getElementsByTagName('textarea');


### PR DESCRIPTION
When the RegExp.test() function (which is used by the getElementsByClassName function) sees a . at the begining of the string it tries to match an extra character at the begining of the string. If 'tinymce' is the first or only class in the element's class list, RegExp will not match any values and will not display the editor. I have therefore added a substring(1) to the options.selector variable to remove this period