### PR TITLE
Update init.jquery.js

### DIFF
--- a/Resources/public/js/init.jquery.js
+++ b/Resources/public/js/init.jquery.js
@@ -10,7 +10,7 @@ function initTinyMCE(options) {
             var textareas = $('textarea');
 
             if (options.selector) {
-                textareas = $('textarea' + options.selector);
+                textareas = $(options.selector);
             }
             textareas.each(function() {
                 var textarea = $(this),


### PR DESCRIPTION
Hi all,
In order to correctly use the `selector` parameter.

This is particularly important when dealing with the `inline` attribute, which enforces to replace textarea with a div (or something else) in order to avoid the `<br data-mce-bogus="1">`