### PR TITLE
TreeBuilder with FOSRest

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,8 +27,7 @@ class Configuration implements ConfigurationInterface
             $rootNode = $treeBuilder->root('stfalcon_tinymce');
         }
 
-        return $treeBuilder
-            ->getRootNode()
+        $rootNode
                 ->children()
                     // Include jQuery (true) library or not (false)
                     ->booleanNode('include_jquery')->defaultFalse()->end()
@@ -84,6 +83,8 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+
+        return $treeBuilder;
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,6 +20,12 @@ class Configuration implements ConfigurationInterface
         $defaults = $this->getTinymceDefaults();
 
         $treeBuilder = new TreeBuilder('stfalcon_tinymce');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('stfalcon_tinymce');
+        }
 
         return $treeBuilder
             ->getRootNode()


### PR DESCRIPTION
Fix BC #248

With the last version of FosRest, you get an ArgumentCountError :

```
!!    #message: "Too few arguments to function Symfony\Component\Config\Definition\Builder\TreeBuilder::__construct(), 0 passed in /.../vendor/stfalcon/tinymce-bundle/Stfalcon/Bundle/TinymceBundle/DependencyInjection/Configuration.php on line 22 and at least 1 expected"
```
