### PR TITLE
Allow PHP 8.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "issues": "https://github.com/stfalcon/TinymceBundle/issues"
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "symfony/framework-bundle": "^5.0",
         "twig/twig": "^2.12|^3.0"
     },


### PR DESCRIPTION
I found no issues using the bundle with PHP8.