### PR TITLE
psr/cache requirements changed 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "issues": "https://github.com/stfalcon/TinymceBundle/issues"
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^8.0",
         "symfony/framework-bundle": "^5.0",
         "twig/twig": "^2.12|^3.0"
     },


### PR DESCRIPTION
Ошибка в требуемой версии РНР.  

itshark@Ubuntu-20:~/student/culinary$ composer req stfalcon/tinymce-bundle='3.0'
./composer.json has been updated
Running composer update stfalcon/tinymce-bundle
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - psr/cache 2.0.0 requires php >=8.0.0 -> your php version (7.4.20) does not satisfy that requirement.
    - doctrine/orm 2.9.2 requires psr/cache ^1 || ^2 || ^3 -> satisfiable by psr/cache[2.0.0].
    - doctrine/orm is locked to version 2.9.2 and an update of this package was not requested.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
itshark@Ubuntu-20:~/student/culinary$ php -v
PHP 7.4.20 (cli) (built: Jun  4 2021 21:24:55) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.20, Copyright (c), by Zend Technologies
