### PR TITLE
Support Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^7.2.5|^8.0",
-        "symfony/framework-bundle": "^5.0",
+        "symfony/framework-bundle": "^5.0|^6.0",
         "twig/twig": "^2.12|^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Tester, seems to work seamlessly on Symfony 6.0

To test it, in your `composer.json`:

```
   "repositories": [
        {
            "type": "git",
            "url": "https://github.com/MonsieurV/TinymceBundle"
        }
    ],
    [...],
   "require": {
        "stfalcon/tinymce-bundle": "dev-master",
        [...]
   }
```

Thanks for the lib @stfalcon :)