### PR TITLE
Ignoring extra keys in the configuration so they can be loaded for plugins

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder
             ->getRootNode()
+                ->ignoreExtraKeys(false)
                 ->children()
                     // Include jQuery (true) library or not (false)
                     ->booleanNode('include_jquery')->defaultFalse()->end()


### PR DESCRIPTION
At this moment it is not possible to load extra configuration in the root configuration for the TinymceBundle.
Some plugins actually require configuration on this place to work.