### PR TITLE
:bug: Fix bundle for twig version 3

### DIFF
--- a/Twig/Extension/StfalconTinymceExtension.php
+++ b/Twig/Extension/StfalconTinymceExtension.php
@@ -4,13 +4,14 @@ namespace Stfalcon\Bundle\TinymceBundle\Twig\Extension;
 use Stfalcon\Bundle\TinymceBundle\Helper\LocaleHelper;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Twig Extension for TinyMce support.
  *
  * @author naydav <web@naydav.com>
  */
-class StfalconTinymceExtension extends \Twig_Extension
+class StfalconTinymceExtension extends AbstractExtension
 {
     /**
      * @var ContainerInterface $container Container interface
@@ -71,7 +72,7 @@ class StfalconTinymceExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            'tinymce_init' => new \Twig_SimpleFunction(
+            'tinymce_init' => new \Twig\TwigFunction(
                 'tinymce_init',
                 [$this, 'tinymceInit'],
                 ['is_safe' => ['html']]


### PR DESCRIPTION
In twig version 3, `\Twig_Extension` and `\Twig_SimpleFunction` have been removed