### PR TITLE
Tag service as twig extension. Closes #269

### DIFF
--- a/Resources/config/service.yaml
+++ b/Resources/config/service.yaml
@@ -4,3 +4,4 @@
 services:
     twig.extension.stfalcon_tinymce:
         class: Stfalcon\Bundle\TinymceBundle\Twig\Extension\StfalconTinymceExtension
+        tags: ['twig.extension']

--- a/Resources/config/service.yaml
+++ b/Resources/config/service.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=../vendor/symfony/dependency-injection/Loader/schema/services.schema.json
 
 services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
     twig.extension.stfalcon_tinymce:
         class: Stfalcon\Bundle\TinymceBundle\Twig\Extension\StfalconTinymceExtension
         tags: ['twig.extension']


### PR DESCRIPTION
Missing a bit in #268 in converting from `service.xml` to `service.yaml`

@fre5h 